### PR TITLE
Replace getResourcePath with getLines.

### DIFF
--- a/Running/runBenchmark.py
+++ b/Running/runBenchmark.py
@@ -1,6 +1,6 @@
 import ThreeHiggs
 
-def getResourcePath(relativePathToResource: str) -> str:
+def getResourcePath(relativePathToResource):
     """ Gives a safe path to a packaged resource.
     
     Returns
@@ -8,11 +8,15 @@ def getResourcePath(relativePathToResource: str) -> str:
     Path to the resource file: str.
     """
 
+
+def getLines(relativePathToResource):
     ## fallback to hardcoded package name if the __package__ call fails
     packageName = __package__ or "ThreeHiggs"
 
     from importlib.resources import files
-    return files(packageName) / relativePathToResource
+    path = files(packageName) / relativePathToResource
+
+    return open(path, encoding = "utf-8").readlines()
 
 from ThreeHiggs.UserInput import UserInput
 userinput = UserInput()
@@ -20,44 +24,37 @@ args = userinput.parse()
 
 ## ---- Configure Veff
 
-hardToSoftFile = getResourcePath(args.hardToSoftFile)
-softScaleRGEFile = getResourcePath(args.softScaleRGEFile)
-softToUltrasoftFile = getResourcePath(args.softToUltraSoftFile)
+hardToSoftFile = getLines(args.hardToSoftFile)
+softScaleRGEFile = getLines(args.softScaleRGEFile)
+softToUltrasoftFile = getLines(args.softToUltraSoftFile)
 
 from ThreeHiggs.MathematicaParsers import parseExpressionSystem
 from ThreeHiggs.ParsedExpression import ParsedExpressionSystem
-vectorMassesSquared = ParsedExpressionSystem(parseExpressionSystem(open(getResourcePath(args.vectorMassesSquaredFile), 
-                                                                        encoding = "utf-8").readlines()))
-
-vectorShortHands = ParsedExpressionSystem(parseExpressionSystem(open(getResourcePath(args.vectorShortHandsFile), 
-                                                                     encoding = "utf-8").readlines()))
+vectorMassesSquared = ParsedExpressionSystem(parseExpressionSystem(getLines(args.vectorMassesSquaredFile)))
+vectorShortHands = ParsedExpressionSystem(parseExpressionSystem(getLines(args.vectorShortHandsFile)))
 
 from ThreeHiggs.MathematicaParsers import parseConstantMatrix
-scalarPermutationMatrix = parseConstantMatrix(open(getResourcePath(args.scalarPermutationFile), 
-                                                   encoding = "utf-8").readlines())["matrix"]
-
+scalarPermutationMatrix = parseConstantMatrix(getLines(args.scalarPermutationFile))["matrix"]
 
 from ThreeHiggs.MathematicaParsers import parseMassMatrix
 from ThreeHiggs.ParsedExpression import MassMatrix
-scalarMassMatrixUpperLeft = MassMatrix(parseMassMatrix(open(getResourcePath(args.scalarMassMatrixUpperLeftFile), encoding = "utf-8").readlines())["matrix"],
-                                       ParsedExpressionSystem(parseExpressionSystem(open(getResourcePath(args.scalarMassMatrixUpperLeftDefinitionsFile),
-                                                                                         encoding = "utf-8").readlines())))
+scalarMassMatrixUpperLeft = MassMatrix(parseMassMatrix(getLines(args.scalarMassMatrixUpperLeftFile))["matrix"],
+                                       ParsedExpressionSystem(parseExpressionSystem(getLines(args.scalarMassMatrixUpperLeftDefinitionsFile))))
 
-scalarMassMatrixBottomRight = MassMatrix(parseMassMatrix(open(getResourcePath(args.scalarMassMatrixBottomRightFile), encoding = "utf-8").readlines())["matrix"],
-                                       ParsedExpressionSystem(parseExpressionSystem(open(getResourcePath(args.scalarMassMatrixBottomRightDefinitionsFile),
-                                                                                         encoding = "utf-8").readlines())))
+scalarMassMatrixBottomRight = MassMatrix(parseMassMatrix(getLines(args.scalarMassMatrixBottomRightFile))["matrix"],
+                                         ParsedExpressionSystem(parseExpressionSystem(getLines(args.scalarMassMatrixBottomRightDefinitionsFile))))
+
 scalarMassMatrices = [scalarMassMatrixUpperLeft, scalarMassMatrixBottomRight]
 
 from ThreeHiggs.MathematicaParsers import parseRotationMatrix
 from ThreeHiggs.ParsedExpression import RotationMatrix
-scalarRotationMatrix = RotationMatrix(parseRotationMatrix(open(getResourcePath(args.scalarRotationFile), 
-                                                               encoding = "utf-8").readlines())["matrix"])
+scalarRotationMatrix = RotationMatrix(parseRotationMatrix(getLines(args.scalarRotationFile)))
 
-veffLines = open(getResourcePath(args.loFile), encoding = "utf-8").readlines()
+veffLines = getLines(args.loFile)
 if (args.loopOrder >= 1):
-    veffLines += open(getResourcePath(args.nloFile), encoding = "utf-8").readlines()
+    veffLines += getLines(args.nloFile)
 if (args.loopOrder >= 2):
-    veffLines += open(getResourcePath(args.nnloFile), encoding = "utf-8").readlines()
+    veffLines += getLines(args.nnloFile)
 
 veff = ParsedExpressionSystem(parseExpressionSystem(veffLines))
 

--- a/src/ThreeHiggs/DimensionalReduction.py
+++ b/src/ThreeHiggs/DimensionalReduction.py
@@ -18,11 +18,11 @@ class DimensionalReduction():
         self.bDoUltrasoftScaleRGE = False
 
 
-    def setupHardToSoftMatching(self, hardToSoftFile: str, softScaleRGEFile: str = None) -> None:
-        """softScaleRGEFile specifies where RGEs are loaded from. If left to None, 
+    def setupHardToSoftMatching(self, hardToSoftLines, softScaleRGELines = None):
+        """softScaleRGELines specifies where RGEs are loaded from. If left to None, 
         will not perform RG running at soft scale."""
 
-        self.matchToSoft.createMatchingRelations(hardToSoftFile)
+        self.matchToSoft.createMatchingRelations(hardToSoftLines)
         #self.matchToSoft.matchingRelations = self.__remove3dSuffices(self.matchToSoft.matchingRelations)
 
         print("Setup Hard -> Soft matching relations.")
@@ -32,17 +32,17 @@ class DimensionalReduction():
         print( list(self.matchToSoft.matchingRelations.keys()) )
         print("")
 
-        if (softScaleRGEFile):
+        if (softScaleRGELines):
             self.bDoSoftScaleRGE = True
             self.softScaleRGE = ParameterMatching()
-            self.softScaleRGE.createMatchingRelations(softScaleRGEFile)
+            self.softScaleRGE.createMatchingRelations(softScaleRGELines)
             #self.softScaleRGE.matchingRelations = self.__remove3dSuffices(self.softScaleRGE.matchingRelations)
 
 
-    def setupSoftToUltrasoftMatching(self, softToUltrasoftFile: str, ultrasoftScaleRGEFile: str = None) -> None:
+    def setupSoftToUltrasoftMatching(self, softToUltrasoftLines, ultrasoftScaleRGELines = None):
         
         ## At US scale let's remove the 3d and US suffices from resulting params. That way they work with directly Veff
-        self.matchToUltrasoft.createMatchingRelations(softToUltrasoftFile)
+        self.matchToUltrasoft.createMatchingRelations(softToUltrasoftLines)
         self.matchToUltrasoft.matchingRelations = self.__remove3dSuffices(self.matchToUltrasoft.matchingRelations, bRemoveSuffixUS=True)
 
         print("Setup Soft -> Ultrasoft matching relations.")

--- a/src/ThreeHiggs/EffectivePotential.py
+++ b/src/ThreeHiggs/EffectivePotential.py
@@ -160,6 +160,7 @@ class VeffParams:
 
         ## OK we have the matrices that DRalgo used. But we now need to assign a correct value to each
         ## matrix element symbol in the Veff expressions. This is currently very hacky 
+
         outDict = self.scalarRotationMatrix(drAlgoRot)
 
         massNames = ["MSsq01", "MSsq02", "MSsq03", "MSsq04", "MSsq05", "MSsq06", "MSsq07", "MSsq08", "MSsq09", "MSsq10", "MSsq11", "MSsq12"]

--- a/src/ThreeHiggs/ParameterMatching.py
+++ b/src/ThreeHiggs/ParameterMatching.py
@@ -33,16 +33,12 @@ class ParameterMatching:
     def createMatchingRelations(self, fileToRead):
         self.parameterNames, self.matchingRelations = self.parseMatchingRelations(fileToRead)
 
-    def parseMatchingRelations(self, filePath: str) -> Tuple[list[str], dict[str, ParsedExpression]]:
-
-        with open(filePath, "r", encoding="utf-8") as file:
-            expressions = file.readlines()
-
+    def parseMatchingRelations(self, lines):
         ## Dict for storing ParsedExpression objects
         parsedExpressions = {}
         parsedSymbols = [] ## Automatically find all symbols that appear in matching relations
 
-        for line in expressions:
+        for line in lines:
             lhs, rhs = map(str.strip, line.split("->"))
 
             from ThreeHiggs.MathematicaParsers import parseExpression

--- a/src/ThreeHiggs/ParsedExpression.py
+++ b/src/ThreeHiggs/ParsedExpression.py
@@ -77,7 +77,7 @@ class MassMatrix:
 
 class RotationMatrix:
     def __init__(self, symbolMap):
-        self.symbolMap = symbolMap
+        self.symbolMap = symbolMap["matrix"]
 
     def __call__(self, numericalM):
         """Evaluates our symbols by plugging in numbers from the input numerical matrix.


### PR DESCRIPTION
Any time we use `getResourcePath` we push it into an `open(...).readlines()` so this PR factories this replacing `getResourcePath` with `getLines`.