### PR TITLE
Store indices as a list for json compatability.

### DIFF
--- a/src/ThreeHiggs/MathematicaParsers.py
+++ b/src/ThreeHiggs/MathematicaParsers.py
@@ -44,7 +44,7 @@ def parseRotationMatrix(lines):
             element = sympyMatrix[i, j]
 
             if element.is_symbol:
-                symbolMap[str(sympyMatrix[i, j])] = i, j
+                symbolMap[str(sympyMatrix[i, j])] = [i, j]
 
     return {"matrix": symbolMap}
 
@@ -100,7 +100,7 @@ class UnitTests(TestCase):
         self.assertEqual(reference, parseMassMatrix(source))
 
     def test_parseRotationMatrix(self):
-        reference = {"matrix": {"mssq00": (0, 0), "mssq11": (1, 1)}}
+        reference = {"matrix": {"mssq00": [0, 0], "mssq11": [1, 1]}}
         source = ["{mssq00, 0}", "{0, mssq11}"]
 
         from ThreeHiggs.MathematicaParsers import parseRotationMatrix

--- a/src/ThreeHiggs/ParsedExpression.py
+++ b/src/ThreeHiggs/ParsedExpression.py
@@ -84,5 +84,5 @@ class RotationMatrix:
         Returns a dict with symbols names as keys.
         """
 
-        return {symbol: numericalM[indices] for symbol, indices in self.symbolMap.items()}
+        return {symbol: numericalM[indices[0]][indices[1]] for symbol, indices in self.symbolMap.items()}
 


### PR DESCRIPTION
Json doesn't have tuples so tuples go to lists when dumping. When loading they remain lists are not compatible with the implicit expansion used by numpy.

So instead we just store the indices as a list as soon as they are created.
