### PR TITLE
Ensure integration test results are clear before running.

### DIFF
--- a/Running/test.sh
+++ b/Running/test.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
 # Fine tests providing partial coverage
+echo Unit tests...
 python3 ../src/ThreeHiggs/UnitTests.py
 
+echo Intergration tests...
+
 # Super coarse test providing full coverage
+echo Intergration test nominal nnlo...
+rm TestResults/*
 python3 runBenchmark.py -l 2 \
                         --firstBenchmark 1 \
                         --lastBenchmark 1 \
@@ -26,6 +31,8 @@ python3 runBenchmark.py -l 2 \
 diff TestResults/BM_1.json ReferenceTestResults/BM_1.json
 
 # Super coarse test providing full coverage, permit complex mass
+echo Intergration test complex mass nnlo...
+rm TestComplexMassResults/*
 python3 runBenchmark.py -l 2 \
                         --firstBenchmark 1 \
                         --lastBenchmark 1 \


### PR DESCRIPTION
Make sure any previous results from `test.sh` are removed before testing again.