### PR TITLE
WIP: Replace ParsedExpressions with Veff module

### DIFF
--- a/Running/runStages.py
+++ b/Running/runStages.py
@@ -1,8 +1,15 @@
+import sys
+sys.path.append("../src/")
 
 from ThreeHiggs.UserInput import UserInput, Stages
+from Veff_generation import generate_veff_module, compile_veff_submodule
+
 args = UserInput().parse()
+
 if args.firstStage <= Stages.convertMathematica <= args.lastStage:
     from ThreeHiggs.ConvertMathematica import convertMathematica
+    generate_veff_module(args)
+    compile_veff_submodule()
     convertMathematica(args)
 
 if args.firstStage <= Stages.generateBenchmark <= args.lastStage:

--- a/src/Veff_generation/__init__.py
+++ b/src/Veff_generation/__init__.py
@@ -1,0 +1,2 @@
+from .generate_veff_module import *
+from .compile_veff_module import *

--- a/src/Veff_generation/compile_veff_module.py
+++ b/src/Veff_generation/compile_veff_module.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Jun 16 17:33:46 2025
+
+@author: john
+"""
+
+import os
+import sys
+import subprocess
+
+
+def compile_veff_submodule():
+    parent_dir = os.path.dirname(os.getcwd())
+    module_dir = os.path.join(parent_dir, 'src', 'ThreeHiggs', 'Veff')
+    setup_path = os.path.join(module_dir, "setup.py")
+    
+    if not os.path.isfile(setup_path):
+        raise FileNotFoundError(f"No setup.py found in {module_dir}")
+    
+    print("Compiling Veff submodule")
+    result = subprocess.run(
+        [sys.executable, "setup.py", "build_ext", "--inplace"],
+        cwd=module_dir,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        print("Compilation failed:")
+        print(result.stderr)
+        raise RuntimeError("Cython build failed")
+    else:
+        print("Cython compilation succeeded:")
+        print(result.stdout)
+        
+    # TODO: Add a clean up step to remove any compilation artifacts.

--- a/src/Veff_generation/compile_veff_module.py
+++ b/src/Veff_generation/compile_veff_module.py
@@ -8,6 +8,7 @@ Created on Mon Jun 16 17:33:46 2025
 
 import os
 import sys
+import time
 import subprocess
 
 
@@ -20,12 +21,14 @@ def compile_veff_submodule():
         raise FileNotFoundError(f"No setup.py found in {module_dir}")
     
     print("Compiling Veff submodule")
+    ti = time.time()
     result = subprocess.run(
         [sys.executable, "setup.py", "build_ext", "--inplace"],
         cwd=module_dir,
         capture_output=True,
         text=True,
     )
+    tf = time.time()
 
     if result.returncode != 0:
         print("Compilation failed:")
@@ -34,5 +37,6 @@ def compile_veff_submodule():
     else:
         print("Cython compilation succeeded:")
         print(result.stdout)
+        print(f'Compilation took {tf - ti} seconds.')
         
     # TODO: Add a clean up step to remove any compilation artifacts.

--- a/src/Veff_generation/generate_veff_module.py
+++ b/src/Veff_generation/generate_veff_module.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Jun 12 20:42:29 2025
+
+@author: john
+"""
+
+import os
+import numpy as np
+
+from .mathematica_parsing import read_lines, get_terms
+
+
+SETUP_FILE = """
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from setuptools import setup, Extension
+from Cython.Build import cythonize
+
+extensions = [
+    Extension("lo", ["lo.pyx"]),
+    Extension("nlo", ["nlo.pyx"]),
+    Extension("nnlo", ["nnlo.pyx"]),
+]
+
+setup(
+    name="Veff_cython",
+    ext_modules=cythonize(
+        extensions, compiler_directives={"language_level": "3"}
+    ),
+)
+"""
+
+
+
+def generate_veff_module(args):
+    """Creates the Veff module.
+    """
+    parent_dir = os.path.dirname(os.getcwd())
+    data_dir   = os.path.join(parent_dir, 'src', 'ThreeHiggs')
+    module_dir = os.path.join(parent_dir, 'src', 'ThreeHiggs', 'Veff')
+    if not os.path.exists(module_dir):
+        os.mkdir(module_dir)
+    print("Generating Veff submodule")
+    
+    #================================== lo ===================================#
+    name = 'lo'
+    lo_file  = os.path.join(data_dir, args.loFile)
+    filename = os.path.join(module_dir, 'lo.pyx')
+    
+    lines = read_lines(lo_file)
+    lo_params, signs, terms = get_terms(lines)
+    generate_lo_submodule(
+        name, filename, lo_params, signs, terms
+    )
+    
+    #================================== nlo ==================================#
+    name     = 'nlo'
+    nlo_file = os.path.join(data_dir, args.nloFile)
+    filename = os.path.join(module_dir, 'nlo.pyx')
+    
+    lines = read_lines(nlo_file)
+    nlo_params, signs, terms = get_terms(lines)
+    generate_lo_submodule(
+        name, filename, nlo_params, signs, terms
+    )
+    
+    #================================== nnlo =================================#
+    name = 'nnlo'
+    nnlo_file = os.path.join(data_dir, args.nnloFile)
+    filename  = os.path.join(module_dir, 'nnlo.pyx')
+    
+    lines = read_lines(nnlo_file)
+    nnlo_params, signs, terms = get_terms(lines)
+    generate_lo_submodule(
+        name, filename, nnlo_params, signs, terms
+    )
+    
+    #================================== Veff =================================#
+    filename = os.path.join(module_dir, 'veff.py')
+    generate_veff_submodule(filename, lo_params, nlo_params, nnlo_params)
+    
+    #================================ init file ==============================#
+    with open(os.path.join(module_dir, '__init__.py'), 'w') as file:
+        file.write("from .veff import *")
+    
+    #=============================== setup file ==============================#
+    with open(os.path.join(module_dir, 'setup.py'), 'w') as file:
+        file.writelines(SETUP_FILE)
+        
+
+
+def generate_veff_submodule(filename, lo_params, nlo_params, nnlo_params):
+    """Creates a submodule with Veff and Veff_params functions (see below).
+    """
+    if os.path.exists(filename):
+        os.remove(filename)
+    
+    with open(filename, 'w') as file:
+        write_veff_function(file, lo_params, nlo_params, nnlo_params)
+        file.write('\n\n')
+        write_veff_params_function(file, lo_params, nlo_params, nnlo_params)
+
+
+
+def write_veff_function(file, lo_params, nlo_params, nnlo_params):
+    """Adds function called Veff to the given file. Veff imports lo, nlo and
+    nnlo functions and evaluates them, returning the results in a tuple.
+    """
+    file.write('from .lo import lo\n')
+    file.write('from .nlo import nlo\n')
+    file.write('from .nnlo import nnlo\n')
+    file.write('\n')
+    
+    # Function name and input
+    file.write('def Veff(\n')
+    
+    params = np.unique(np.concat((lo_params, nlo_params, nnlo_params)))
+    for param in params:
+        param = convert_to_cython_syntax(param)
+        file.write(f'    {param} = 1,\n')
+    
+    file.write('    ):\n')
+    
+    # Function body
+    file.write('    val_lo = lo(\n')
+    for param in lo_params:
+        param = convert_to_cython_syntax(param)
+        file.write(f'        {param},\n')
+    file.write('    )\n')
+    
+    file.write('    val_nlo = nlo(\n')
+    for param in nlo_params:
+        param = convert_to_cython_syntax(param)
+        file.write(f'        {param},\n')
+    file.write('    )\n')
+    
+    file.write('    val_nnlo = nnlo(\n')
+    for param in nnlo_params:
+        param = convert_to_cython_syntax(param)
+        file.write(f'        {param},\n')
+    file.write('    )\n')
+    
+    file.write('    return (val_lo, val_nlo, val_nnlo)\n')
+    
+
+
+def write_veff_params_function(file, lo_params, nlo_params, nnlo_params):
+    """Adds a function called Veff_params to the given file. Veff_params
+    returns a tuple of parameters for the corresponding Veff function. The
+    parameters are pulled from a provided parameter dictionary.
+    """
+    file.write('def Veff_params(params):\n')
+    file.write('    return (\n')
+    
+    params = np.unique(np.concat((lo_params, nlo_params, nnlo_params)))
+    for param in params:
+        param = convert_to_cython_syntax(param)
+        file.write(f'        params["{param}"],\n')
+    file.write('    )\n')
+
+
+
+def generate_lo_submodule(name, filename, params, signs, terms):
+    """Creates a cython module with a function that evaluates an expression for
+    Veff. 
+    
+    The expression is assumed to be broken into a list of `terms` to be added 
+    together. The sign of each term should be in `signs` and `params` is an 
+    array of parameters that appear in the expression.
+    """
+    if os.path.exists(filename):
+        os.remove(filename)
+    
+    with open(filename, 'w') as file:
+        # Function imports used by Veff
+        file.write('from libc.complex cimport csqrt\n')
+        file.write('from libc.complex cimport clog\n')
+        file.write('from libc.math cimport M_PI\n')
+        file.write('\n')
+        
+        # Function declaration and inputs
+        file.write(f'cpdef double complex {name}(\n')
+        
+        for param in params:
+            param = convert_to_cython_syntax(param)
+            file.write(f'    double complex {param},\n')
+        
+        file.write('    ):\n')
+        
+        # Function body
+        file.write('    cdef double complex a = 0.0\n')
+        
+        term = convert_to_cython_syntax(terms[0])
+        file.write(f'    a += {term}\n')
+        
+        for sign, term in zip(signs, terms[1:]):
+            term = convert_to_cython_syntax(term)
+            if sign > 0:
+                file.write(f'    a += {term}\n')
+            else:
+                file.write(f'    a -= {term}\n')
+        
+        file.write('    return a\n')
+        
+
+
+def convert_to_cython_syntax(term):
+    term = term.replace('Sqrt', 'csqrt')
+    term = term.replace('Pi', 'M_PI')
+    term = term.replace('Log', 'clog')
+    term = term.replace('[', '(')
+    term = term.replace(']', ')')
+    term = term.replace('^', '**')
+    term = term.replace('λ', 'lam')
+    term = term.replace('μ', 'mu')
+    return term

--- a/src/Veff_generation/mathematica_parsing.py
+++ b/src/Veff_generation/mathematica_parsing.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Jun 12 20:40:32 2025
+
+@author: john
+"""
+
+import re
+import numpy as np
+
+
+def read_lines(filename):
+    """Reads the expression in the given file and breaks it into a list of 
+    lines, each line representing a term in the expression to be summed.
+    """
+    num_unpaired_brackets = 0
+    next_line = []
+    lines = []
+    
+    with open(filename, 'r') as file:
+        while True:    
+            char = file.read(1)
+            if not char:
+                lines.append(''.join(next_line))
+                break
+            
+            next_line.append(char)
+            
+            if char == '(':
+                num_unpaired_brackets += 1
+            elif char == ')':
+                num_unpaired_brackets -= 1
+                
+            if char == ' ' and num_unpaired_brackets == 0:
+                lines.append(''.join(next_line))
+                next_line = []
+    
+    return lines
+
+
+
+def find_parameters(expression):
+    """Returns a list of parameter names in the given expression.
+    """
+    pattern = r"[a-zA-Z_\u0370-\u03FF][\w\u0370-\u03FF]*"
+    tokens = re.findall(pattern, expression)
+    # Exclude known functions or keywords (extend as needed)
+    known_functions = {"Sqrt", "Log", "Pi"}  # Add others as necessary
+    return [token for token in tokens if token not in known_functions]
+
+
+
+def get_terms(lines):
+    """Breaks the given list of lines (ie terms to be summed in an expression)
+    into two lists: a list containing the terms to be summed and a list of 
+    leading signs for each term (excluding the first term).
+    
+    A set of all parameters that appear in the expression is also returned.
+    """
+    params = set()
+    terms = []
+    signs = []
+    
+    for line in lines:
+        if line in ["+ ", "- "]:
+            signs.append(1 if line == "+ " else -1)
+            continue
+        
+        for param in find_parameters(line):
+            params.add(param)
+        
+        terms.append(line)
+        
+    params = np.sort(list(params))
+    return params, signs, terms


### PR DESCRIPTION
One idea for optimising the current approach is to convert mathematica expressions directly into callable functions rather than parsing them into ParsedExpression objects. The idea is that callable functions should avoid the overhead that comes with python's builtin eval function which should be avoided inside performance critical sections of code.

This could be achieved by writing a set of functions that generate a submodule (called `Veff` say) with the callable functions in it. The initial commit to this PR has a proof of concept implementation of this. The Veff_generation module exposes a `generate_veff_module` function and a `compile_veff_submodule` function which generates and compiles a python function called `Veff` and cython functions called `lo`, `nlo` and `nnlo`. The cython functions evaluate the mathematica expressions and Veff calls the cython functions and returns the results in a tuple.

`Veff` can be used inside of an `EffectivePotential` object when evaluating the potential - instead of using `self.expressions.evaluate`. Comparing `Veff` against `self.expressions.evaluate` inside my debugger shows it produces the same answer (up to rounding error) and is significantly faster:
![Screenshot from 2025-06-16 18-14-17](https://github.com/user-attachments/assets/90573684-9479-4f8e-a594-d84f41b9a74b)

Running a benchmark with `--loopOrder 2` was also faster when using `Veff`.

Some next steps might be:
- Compiling the cython code for nnlo can take up a big chunk of ram. I think optimising the nnlo expression can go a long way in reducing this. This could involve precomputing repeated expressions etc to reduce the complexity of the nnlo expression. It should also make the Veff function faster.
- cython needs to be added as a dependency (it's easy to install with pip) 
- Remove the ParsedExpression infrastructure.
- Veff currently computes all three functions (`lo`, `nlo` and `nnlo`) regardless of any command line args. Some refactoring of the Veff module generation needs to happen to make the number of terms to evaluate optional if that's needed.
- Rather than cython, it would be interesting to generate a python module and JIT compile it to see how it compares.
- The time to execute `Veff` is about as long as it takes to prepare the parameters with `compFieldDepParams`. Optimising this function should lead to further performance improvements 
![Screenshot from 2025-06-16 18-14-53](https://github.com/user-attachments/assets/fd17aebe-dea2-47b9-8f58-8896890b01e0)
   