### PR TITLE
Handle non-pert beta function

### DIFF
--- a/src/Bloop/TransitionFinder.py
+++ b/src/Bloop/TransitionFinder.py
@@ -8,7 +8,6 @@ from Bloop.PDGData import mTop, mW, mZ, higgsVEV
 
 
 def bIsPerturbative(params, pertSymbols, allSymbols):
-    ## Should actually check vertices but not a feature in DRalgo at time of writting
     for pertSymbol in pertSymbols:
         if abs(params[allSymbols.index(pertSymbol)]) > 4 * pi:
             return False
@@ -83,7 +82,6 @@ class TrackVEV:
         )
         
         if not solvedBetaFunction.success:
-            print(1)
             return minimizationResults | {"failureReason":  solvedBetaFunction.message}
         
         betaSpline4D = {


### PR DESCRIPTION
In cases where the couplings become large and the 4D beta function breaks down and solve_ivp fails we now extract the error message and exit the benchmark.